### PR TITLE
Fixes #269. Fix Travis-CI implementation by working around a dependency mismatch to install fiona. This will likely be fixed when Travis moves Ubuntu 14.04 to Production. Additionally, this fixes a race-condition that was causing Duplicate Primary Keys for the Tag objects during tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: python
+addons:
+  postgresql: "9.3"
 python:
   - "2.7"
 before_install:
   - sudo apt-get -y update
 install:
-  - DEBIAN_FRONTEND=noninteractive sudo apt-get -y install python-dev build-essential python-dbus python-gst0.10 postgresql-server-dev-9.3 postgresql-9.3-postgis-2.1
+  - sudo apt-get -y install libgdal-dev
+  - pip install fiona
+  - sudo apt-get -y install libgdal1
+  - sudo apt-get -y install python-dev build-essential python-dbus python-gst0.10 postgresql-server-dev-9.3 postgresql-9.3-postgis-2.1
   - sudo su - postgres -c 'psql -c "create role round superuser login;"'
   - sudo su - postgres -c 'psql -c "create database roundware"'
   - sudo su - postgres -c 'psql -c "grant all on database roundware to round"'

--- a/tests/roundwared/test_db.py
+++ b/tests/roundwared/test_db.py
@@ -27,8 +27,8 @@ class TestGetRecordings(RoundwaredTestCase):
                                    language=self.english)
         self.tagcat2 = mommy.make(TagCategory)
         self.tagcat3 = mommy.make(TagCategory)
-        self.tag2 = mommy.make(Tag, tag_category=self.tagcat2, value='tag2')
-        self.tag3 = mommy.make(Tag, tag_category=self.tagcat3, value='tag3')
+        self.tag2 = mommy.make(Tag, tag_category=self.tagcat2, value='tag2', id=2)
+        self.tag3 = mommy.make(Tag, tag_category=self.tagcat3, value='tag3', id=3)
         self.masterui1 = mommy.make(MasterUI, project=self.project1,
                                     ui_mode=MasterUI.LISTEN,
                                     tag_category=self.tagcat1)
@@ -131,8 +131,8 @@ class TestFilterRecsForTags(RoundwaredTestCase):
 
         self.tagcat2, self.tagcat3, self.tagcat4 = \
             mommy.make(TagCategory, _quantity=3)
-        self.tag2 = mommy.make(Tag, tag_category=self.tagcat2, value='tag2')
-        self.tag3 = mommy.make(Tag, tag_category=self.tagcat3, value='tag3')
+        self.tag2 = mommy.make(Tag, tag_category=self.tagcat2, value='tag2', id=2)
+        self.tag3 = mommy.make(Tag, tag_category=self.tagcat3, value='tag3', id=3)
         self.project1 = mommy.make(Project, name='Project One')
         self.project2 = mommy.make(Project, name='Project Two')
         self.masterui1 = mommy.make(MasterUI, project=self.project1,


### PR DESCRIPTION
This PR fixes #269. Fixes Travis implementation, and addresses race-condition in tests.
